### PR TITLE
docker: Pass "daemon", instead of "-d"

### DIFF
--- a/docker/rc.docker
+++ b/docker/rc.docker
@@ -37,7 +37,7 @@ docker_start() {
         rm -f ${DOCKER_PIDFILE}
       fi
     fi
-    nohup ${DOCKER} -d -p ${DOCKER_PIDFILE} ${DOCKER_OPTS} >> ${DOCKER_LOG} 2>&1 &
+    nohup ${DOCKER} daemon -p ${DOCKER_PIDFILE} ${DOCKER_OPTS} >> ${DOCKER_LOG} 2>&1 &
   fi
 }
 


### PR DESCRIPTION
When running Docker, the logs indicate that "-d" is deprecated and
that "daemon" is what should be used instead.
